### PR TITLE
Add User-Agent to Request Header

### DIFF
--- a/content_script/validate_problem.py
+++ b/content_script/validate_problem.py
@@ -26,7 +26,7 @@ def validate_image(image, checksum, old_path):
                     continue
         try:
             i = re.sub(r"https://imgur\.com/([\d\w]+)", r"https://i.imgur.com/\g<1>.png", i)
-            r = requests.get(i)
+            r = requests.get(i, headers={ "user-agent": "OATutor/1.0.0" })
         except:
             raise Exception("Image retrieval error")
         with open(name, 'wb') as outfile:


### PR DESCRIPTION
Many websites have measures against webscraping on the internet. One common measure is to check the `User-Agent` header on a request. If there is no user agent, the website typically assumes that the incoming request is from a web scraper and blocks the request or subsequent requests.

This is what happens when trying to validate the image by downloading it onto the platform. An easy way to fix this is to add the `User-Agent` into the header. For reference, OATutor doesn't have this issue since the request is being run through a browser, which sets the `User-Agent` automatically.