### PR TITLE
Properly handle operators with a parameter negation

### DIFF
--- a/content_script/process_text.py
+++ b/content_script/process_text.py
@@ -320,7 +320,7 @@ def handle_word(word, coord=True):
     for item in scientific_notation:
         word = re.sub(item[0] + r"\{" + item[1] + r"\}", item[0] + "\\\\times {" + item[1] + "}", word)
     
-    word = re.sub(r"\\operatorname{([^(negneg)]*)negneg}\\left\(", r"\g<1>\\left(-", word)
+    word = re.sub(r"\\operatorname{(.*?(?=negneg))negneg}\\left\(", r"\g<1>\\left(-", word)
     word = re.sub(r"\\operatorname{invert}", r"\\pm ", word)
     word = re.sub(r"\+plusminus\+", "\\\\pm ", word)
     word = re.sub(r"\\operatorname{(\w)}", r"\g<1>", word)


### PR DESCRIPTION
For some reason, the original check for the operator name when looking at a function like `cos(-x)` checked if the characters `n`, `e`, or `g` did not appear in the function name. This means that functions like `cos` would render correctly while `sin` and `tan` would not. This corrects the regex to use the appropriate positive lookahead.