### PR TITLE
Wrap pi in latex if alone

### DIFF
--- a/content_script/process_text.py
+++ b/content_script/process_text.py
@@ -45,6 +45,8 @@ def preprocess_text_to_latex(text, tutoring=False, stepMC=False, render_latex="T
     if render_latex:
         text = str(text)
         text = regex.sub(lambda match: replace[match.group(0)], text)
+        if text == 'pi':
+            text = f'$$\\{text}$$'
         if not re.findall(r"[\[|\(][-\d\s\w/]+,[-\d\s\w/]+[\)|\]]", text): #Checking to see if there are coordinates/intervals before replacing () with []
             text = regex.sub(lambda match: conditionally_replace[match.group(0)], text)
 


### PR DESCRIPTION
For some reason, if and only if `pi` is the only statement in the string, it gets rendered as text instead of the symbol. As such, this just wraps the pi text in latex so that it renders properly.